### PR TITLE
Center the table so the numbers look a bit better

### DIFF
--- a/style.css
+++ b/style.css
@@ -170,6 +170,7 @@ h1 {
 
 table {
     position: relative;
+    margin: 0 auto;
 }
 
 table td {


### PR DESCRIPTION
Before the numbers were shown on the side, now they are centered in the middle.
![image](https://user-images.githubusercontent.com/743421/233583048-13f99cc5-1bf9-4b52-8998-7ca518968fce.png)

Updated version:
![image](https://user-images.githubusercontent.com/743421/233583196-6e3e183a-0e17-4baa-929c-f51fe4adac47.png)
